### PR TITLE
Removed dependency over id=inputImage and Added error display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ export class ExampleComponent {
       cancelBtnClass: null, // default bootstrap styles, btn btn-default
       applyBtnName: 'Apply', // default Apply
       applyBtnClass: null, // default bootstrap styles, btn btn-primary
+      errorMsgs: {  // These error msgs are to be displayed to the user (not the ones sent in returnData)
+        4000: null, // default `Max size allowed is ${maxsize}kb, current size is ${currentSize}kb`
+        4001: null  // default 'When sent to the server, something went wrong'
+      },
       fdName: 'file', // default 'file', this is  Content-Disposition: form-data; name="file"; filename="fire.jpg"
       aspectRatio: 1 / 1, // default 1 / 1, for example: 16 / 9, 4 / 3 ...
       viewMode: 0 // default 0, value can be 0, 1, 2, 3
@@ -71,15 +75,15 @@ export class ExampleComponent {
     //  1. Max size
     // {
     //     code: 4000,
-    //     data: null,
-    //     msg: `The size is max than ${this.viewConfig.maxsize}, now size is ${currentSize}k`
+    //     data: currentSize,
+    //     msg: `Max size allowed is ${this.viewConfig.maxsize / 1024}kb, current size is ${currentSize}kb`
     //  }
 
     //  2. Error
     //  {
     //       code: 4001,
     //       data: null,
-    //       msg: 'ERROR: When sent to server, something wrong, please check the server url.'
+    //       msg: 'ERROR: When sent to the server, something went wrong, please check the server url.'
     //  }
 
     //  3. Image type error
@@ -93,7 +97,7 @@ export class ExampleComponent {
     //  {
     //       code: 2000,
     //       data,
-    //       msg: 'The image was sent to server successly'
+    //       msg: 'The image was sent to the server successfully'
     //  }
   }
 }

--- a/src/ngx-cropper.component.css
+++ b/src/ngx-cropper.component.css
@@ -40,15 +40,17 @@
   padding: 10px;
 }
 
+.crop-box-error {
+  color: red;
+  text-align: center;
+  font-weight: 600;
+}
+
 .crop-box .crop-box-footer {
   border-top: 1px solid #ddd;
   padding: 10px;
   display: flex;
-  justify-content: flex-end;
-}
-
-.crop-box .crop-box-footer a:last-child {
-  margin-left: 5px;
+  justify-content: space-around;
 }
 
 .crop-box .crop-box-close {
@@ -66,7 +68,8 @@
 }
 
 .crop-box .crop-box-close span::before {
-  content: "x";
+  content: "×";
+  font-size: 25px;
 }
 
 .inline-block {

--- a/src/ngx-cropper.component.ts
+++ b/src/ngx-cropper.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter, AfterViewInit } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, ViewChild, AfterViewInit } from '@angular/core';
 
 import Cropper from 'cropperjs';
 
@@ -11,8 +11,8 @@ import { NgxCropperOption } from './ngx-cropper.model';
     <section class="inline-block">
       <a class="btn btn-primary" href="javascript: void(0)"
       [ngClass]="viewConfig.uploadBtnClass"
-      onclick="document.getElementById('inputImage').click()">{{viewConfig.uploadBtnName}}</a>
-      <input id="inputImage" type="file" class="hide" hidden>
+      (click)="inputImage.click()">{{viewConfig.uploadBtnName}}</a>
+      <input #inputImage type="file" class="hide" hidden>
     </section>
     <section class="crop-container" *ngIf="isShow === true">
       <div class="crop-box">
@@ -43,6 +43,7 @@ export class NgxCropperComponent implements OnInit, AfterViewInit {
   public viewConfig: NgxCropperOption;
   @Input() private config: NgxCropperOption;
   @Output() private returnData: EventEmitter<string> = new EventEmitter<string>();
+  @ViewChild('inputImage') inputImage: any;
 
   private fileName: string;
   private fileType: string;
@@ -72,9 +73,8 @@ export class NgxCropperComponent implements OnInit, AfterViewInit {
   public ngAfterViewInit() {
     //  init upload btn, after dom content loaded init down.
     setTimeout(() => {
-      const dom = (this.dom = document.getElementById('inputImage') as HTMLInputElement);
-      this.dom.onchange = () => {
-        const files = dom.files;
+      this.inputImage.nativeElement.onchange = () => {
+        const files = this.inputImage.nativeElement.files;
 
         if (files && files.length > 0) {
           this.isShow = true;
@@ -168,6 +168,7 @@ export class NgxCropperComponent implements OnInit, AfterViewInit {
    */
   public onCancel() {
     this.isShow = false;
+    this.inputImage.nativeElement.value = '';
   }
 
   /**

--- a/src/ngx-cropper.model.ts
+++ b/src/ngx-cropper.model.ts
@@ -8,6 +8,7 @@ export class NgxCropperOption {
   public cancelBtnClass?: string;
   public applyBtnName?: string;
   public applyBtnClass?: string;
+  public errorMsgs?: object;
   public fdName?: string;
   public aspectRatio?: number;
   public viewMode?: number; // 0, 1, 2, 3


### PR DESCRIPTION
**Commit:** Remove Dependency over id=inputImage 
- Solves #4 
- Removes dependency over dom
- Solves #5

**Commit:** Allow custom errors messages to be displayed in the crop-box
-  Error messages are displayed now when there is an error
- The displayed error messages can be customized from the config
- The default error messages are slightly modified and corrected .
- The apply button is now disabled when the image is being sent to the server, to prevent multiple sending.